### PR TITLE
rerender blaze view if template changes

### DIFF
--- a/blaze-react-component/blaze-react-component-client.js
+++ b/blaze-react-component/blaze-react-component-client.js
@@ -43,6 +43,11 @@ class BlazeComponent extends Component {
     );
   }
 
+  shouldComponentUpdate(nextProps) {
+    // Never call render() for props except template again; Blaze will do what's necessary.
+    return nextProps.template !== this.props.template;
+  }
+
   componentWillReceiveProps(nextProps) {
     this._blazeData.set(_.omit(nextProps, 'template'));
   }

--- a/blaze-react-component/blaze-react-component-client.js
+++ b/blaze-react-component/blaze-react-component-client.js
@@ -7,6 +7,17 @@ import { Template } from 'meteor/templating';
 class BlazeComponent extends Component {
 
   componentDidMount() {
+    this.renderBlazeView();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.template != this.props.template) {
+      Blaze.remove(this._blazeView);
+      this.renderBlazeView();
+    }
+  }
+
+  renderBlazeView() {
     this._blazeData = new ReactiveVar(_.omit(this.props, 'template'));
 
     let template, tArg = this.props.template;
@@ -34,11 +45,6 @@ class BlazeComponent extends Component {
 
   componentWillReceiveProps(nextProps) {
     this._blazeData.set(_.omit(nextProps, 'template'));
-  }
-
-  shouldComponentUpdate() {
-    // Never call render() again; Blaze will do what's necessary.
-    return false;
   }
 
   componentWillUnmount() {

--- a/test-app/client/main.spec.js
+++ b/test-app/client/main.spec.js
@@ -49,6 +49,8 @@ describe('blaze-react-component', () => {
     wrapper.setProps({ text: 'OK2' });
     Tracker.flush();
     expect(Blaze.prototype.render.calledOnce).to.be.true;
+    // Unwrap the spy
+    Blaze.prototype.restore();
   });
 
   it("re-render when change template", () => {
@@ -57,6 +59,8 @@ describe('blaze-react-component', () => {
     wrapper.setProps({ template: 'test2' });
     Tracker.flush();
     expect(Blaze.prototype.render.calledOnce).to.be.false;
+    // Unwrap the spy
+    Blaze.prototype.restore();
   });
 
 });

--- a/test-app/client/main.spec.js
+++ b/test-app/client/main.spec.js
@@ -51,4 +51,12 @@ describe('blaze-react-component', () => {
     expect(Blaze.prototype.render.calledOnce).to.be.true;
   });
 
+  it("re-render when change template", () => {
+    spy(Blaze.prototype, 'render');
+    const wrapper = mount(<Blaze template="test1" text="OK" />);
+    wrapper.setProps({ template: 'test2' });
+    Tracker.flush();
+    expect(Blaze.prototype.render.calledOnce).to.be.false;
+  });
+
 });

--- a/test-app/client/main.spec.js
+++ b/test-app/client/main.spec.js
@@ -50,7 +50,7 @@ describe('blaze-react-component', () => {
     Tracker.flush();
     expect(Blaze.prototype.render.calledOnce).to.be.true;
     // Unwrap the spy
-    Blaze.prototype.restore();
+    Blaze.prototype.render.restore();
   });
 
   it("re-render when change template", () => {
@@ -60,7 +60,7 @@ describe('blaze-react-component', () => {
     Tracker.flush();
     expect(Blaze.prototype.render.calledOnce).to.be.false;
     // Unwrap the spy
-    Blaze.prototype.restore();
+    Blaze.prototype.render.restore();
   });
 
 });


### PR DESCRIPTION
You can reproduce the problem if you use FlowRouter with react-mounter like this:

```
FlowRouter.route('/page1', {
    ...
    action: function() {
        mount(Layout, {
            content: <Blaze template="template1" />,
        });
    }
});

FlowRouter.route('/page2', {
    ...
    action: function() {
        mount(Layout, {
            content: <Blaze template="template2" />,
        });
    }
});
```

The blaze template will not update if you change the route.
