### PR TITLE
Add meteor-blaze-components compatibility

### DIFF
--- a/blaze-react-component/blaze-react-component-client.js
+++ b/blaze-react-component/blaze-react-component-client.js
@@ -4,7 +4,7 @@ import { Blaze } from 'meteor/blaze';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { Template } from 'meteor/templating';
 
-class BlazeComponent extends Component {
+class BlazeReactComponent extends Component {
 
   componentDidMount() {
     this.renderBlazeView();
@@ -63,8 +63,8 @@ class BlazeComponent extends Component {
 }
 
 blazeToReact = function(template) {
-  return (props) => <BlazeComponent {...props} template={template} />;
+  return (props) => <BlazeReactComponent {...props} template={template} />;
 }
 
 export { blazeToReact };
-export default BlazeComponent;
+export default BlazeReactComponent;

--- a/blaze-react-component/package.js
+++ b/blaze-react-component/package.js
@@ -18,7 +18,7 @@ Package.onUse(function(api) {
 
   api.mainModule('blaze-react-component-server.js', 'server');
 
-  api.export('BlazeComponent');
+  api.export('BlazeReactComponent');
   api.export('blazeToReact');
 });
 


### PR DESCRIPTION
If anybody else wants to use this package and their project is already using [meteor-blaze-components](https://github.com/peerlibrary/meteor-blaze-components), this fixes the name collision on `BlazeComponent`.