### PR TITLE
blaze dep update

### DIFF
--- a/blaze-react-component/package.js
+++ b/blaze-react-component/package.js
@@ -9,7 +9,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom([ '3.0-beta.0' ]);
   api.use('ecmascript');
-  api.use('blaze@2.8.0');
+  api.use('blaze@2.0.3 || 3.0.0-alpha300.17');
   api.use('templating@1.0.3');
   api.use('underscore');
 


### PR DESCRIPTION
there was an incompatible blaze dependancy in the `package.js`. this should allow people to use the `v2` version of this package more easily on meteor 3